### PR TITLE
Tidy targets to run CI against

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,4 +1,12 @@
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
 name: CI
 jobs:
   test:


### PR DESCRIPTION
## Problems

- Meaningless running CI against PR twice (double), for `push` and `pull_request`.